### PR TITLE
Override default "/" mapping behavior

### DIFF
--- a/event_organizer.go
+++ b/event_organizer.go
@@ -25,8 +25,7 @@ func (e *EventOrganizer) Start() error {
 // router initialize routings
 func (e *EventOrganizer) router() http.Handler {
 	router := http.NewServeMux()
-	// router.Handle("/", http.FileServer(http.Dir(e.PublicPath)))
-	router.Handle("/", &srv.GetHomepage{App: e})
+	router.Handle("/", homePageOrFileServer(&srv.GetHomepage{App: e}, http.FileServer(http.Dir(e.PublicPath))))
 	router.Handle("/calendar", &srv.GetCalendar{App: e})
 
 	router.Handle("/api/events", &srv.GetEvents{App: e})

--- a/middlewares.go
+++ b/middlewares.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"net/http"
+)
+
+func homePageOrFileServer(homePage http.Handler, fileServer http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if(r.URL.Path == "/"){
+			homePage.ServeHTTP(w, r)
+		} else {
+			fileServer.ServeHTTP(w, r)
+		}
+	});
+}


### PR DESCRIPTION
Added a middleware to discriminate calls to "/" and "/{resourcePath}".